### PR TITLE
Fixed assign request bug

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = HealthHub
 
 https://travis-ci.com/CS2103-AY1819S2-W09-2/main[image:https://travis-ci.com/CS2103-AY1819S2-W09-2/main.svg?branch=master[Build Status]]
-https://coveralls.io/github/CS2103-AY1819S2-W09-2?branch=master[image:https://coveralls.io/repos/github/main/badge.svg?branch=master[Coverage Status]]
+https://coveralls.io/github/CS2103-AY1819S2-W09-2/main?branch=master[image:https://coveralls.io/repos/github/CS2103-AY1819S2-W09-2/main/badge.svg?branch=master[Coverage Status]]
 image:https://api.codacy.com/project/badge/Grade/59b2e00f57cf432eab91667b827851b9[link="https://app.codacy.com/app/CS2103-AY1819S2-W09-2/main?utm_source=github.com&utm_medium=referral&utm_content=CS2103-AY1819S2-W09-2/main&utm_campaign=Badge_Grade_Dashboard"]
 
 ifdef::env-github[]

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -18,5 +18,7 @@ public class Messages {
         + "format! \n%1$s";
     public static final String MESSAGE_REQUEST_ONGOING_CANNOT_CLEAR = "There is at least one "
         + "ongoing request in the list, request list cannot be cleared.";
+    public static final String MESSAGE_REQUEST_COMPLETED_CANNOT_ASSIGN = "Completed request "
+        + "cannot be assigned. To make changes to a completed request, use edit instead.";
 
 }

--- a/src/main/java/seedu/address/logic/commands/request/AssignRequestCommand.java
+++ b/src/main/java/seedu/address/logic/commands/request/AssignRequestCommand.java
@@ -70,6 +70,9 @@ public class AssignRequestCommand extends Command implements RequestCommand {
             }
 
             Request request = lastShownRequestList.get(i.getZeroBased());
+            if (request.isCompleted()) {
+                throw new CommandException(Messages.MESSAGE_REQUEST_COMPLETED_CANNOT_ASSIGN);
+            }
             requestsToAdd.add(request);
         }
 

--- a/src/test/java/seedu/address/logic/commands/request/AssignRequestCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/request/AssignRequestCommandTest.java
@@ -108,6 +108,20 @@ class AssignRequestCommandTest {
     }
 
     @Test
+    public void execute_completedRequest_throwsCommandException() {
+        Set<Index> requestIds = new HashSet<>();
+        requestIds.add(validRequestIndex);
+        Request req = model.getFilteredRequestList().get(validRequestIndex.getZeroBased());
+        Request newRequest = new Request(req);
+        newRequest.complete();
+        model.setRequest(req, newRequest);
+        AssignRequestCommand assignRequestCommand =
+            new AssignRequestCommand(validHealthWorkerIndex, requestIds);
+        assertThrows(CommandException.class, () -> assignRequestCommand.execute(model,
+            commandHistory), Messages.MESSAGE_REQUEST_COMPLETED_CANNOT_ASSIGN);
+    }
+
+    @Test
     public void equals() {
         Set<Index> indexOne = new HashSet<>();
         indexOne.add(INDEX_FIRST);


### PR DESCRIPTION
Fixed bug where completed requests can be assigned to healthworkers, causing the request status to revert back to ongoing. 